### PR TITLE
스프링 데이터 JPA가 제공하는 Querydsl 기능

### DIFF
--- a/querydsl/src/main/java/study/querydsl/repository/MemberRepository.java
+++ b/querydsl/src/main/java/study/querydsl/repository/MemberRepository.java
@@ -3,12 +3,14 @@ package study.querydsl.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 
 import study.querydsl.entity.Member;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom,
+	QuerydslPredicateExecutor<Member> {
 
 	List<Member> findByUsername(String username);
 

--- a/querydsl/src/main/java/study/querydsl/repository/MemberRepositoryCustomImpl.java
+++ b/querydsl/src/main/java/study/querydsl/repository/MemberRepositoryCustomImpl.java
@@ -11,6 +11,7 @@ import javax.persistence.EntityManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -20,13 +21,34 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import study.querydsl.dto.MemberSearchCondition;
 import study.querydsl.dto.MemberTeamDto;
 import study.querydsl.dto.QMemberTeamDto;
+import study.querydsl.entity.Member;
 
-public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
+public class MemberRepositoryCustomImpl extends QuerydslRepositorySupport implements MemberRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
 
 	public MemberRepositoryCustomImpl(EntityManager em) {
+		super(Member.class);
 		this.queryFactory = new JPAQueryFactory(em);
+	}
+
+	public List<MemberTeamDto> searchByQuerydslRepositorySupport(MemberSearchCondition condition) {
+		return from(member)
+			.leftJoin(member.team, team)
+			.where(
+				usernameEq(condition.getUsername()),
+				teamNameEq(condition.getTeamName()),
+				ageGoe(condition.getAgeGoe()),
+				ageLoe(condition.getAgeLoe())
+			)
+			.select(new QMemberTeamDto(
+				member.id,
+				member.username,
+				member.age,
+				team.id,
+				team.name)
+			)
+			.fetch();
 	}
 
 	@Override

--- a/querydsl/src/main/java/study/querydsl/repository/MemberTestRepository.java
+++ b/querydsl/src/main/java/study/querydsl/repository/MemberTestRepository.java
@@ -1,0 +1,109 @@
+package study.querydsl.repository;
+
+import static org.springframework.util.StringUtils.hasText;
+import static study.querydsl.entity.QMember.member;
+import static study.querydsl.entity.QTeam.team;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+
+import study.querydsl.dto.MemberSearchCondition;
+import study.querydsl.entity.Member;
+import study.querydsl.repository.support.Querydsl4RepositorySupport;
+
+@Repository
+public class MemberTestRepository extends Querydsl4RepositorySupport {
+
+	public MemberTestRepository() {
+		super(Member.class);
+	}
+
+	public List<Member> basicSelect() {
+		return select(member)
+			.from(member)
+			.fetch();
+	}
+
+	public List<Member> basicSelectFrom() {
+		return selectFrom(member)
+			.fetch();
+	}
+
+	public Page<Member> searchPageByApplyPage(MemberSearchCondition condition, Pageable pageable) {
+		JPAQuery<Member> query = selectFrom(member)
+			.leftJoin(member.team, team)
+			.where(usernameEq(condition.getUsername()),
+				   teamNameEq(condition.getTeamName()),
+				   ageGoe(condition.getAgeGoe()),
+				   ageLoe(condition.getAgeLoe())
+			);
+		List<Member> content = getQuerydsl().applyPagination(pageable, query)
+											.fetch();
+		return PageableExecutionUtils.getPage(content, pageable, query::fetchCount);
+	}
+
+	/**
+	 * Querydsl4RepositorySupport 기능 사용
+	 */
+	public Page<Member> applyPagination(MemberSearchCondition condition, Pageable pageable) {
+		return applyPagination(pageable, query ->
+			query.selectFrom(member)
+				 .leftJoin(member.team, team)
+				 .where(usernameEq(condition.getUsername()),
+						teamNameEq(condition.getTeamName()),
+						ageGoe(condition.getAgeGoe()),
+						ageLoe(condition.getAgeLoe())
+				 )
+		);
+	}
+
+	/**
+	 * applyPagination, count 쿼리 추가
+	 */
+	public Page<Member> applyPagination2(MemberSearchCondition condition, Pageable pageable) {
+		return applyPagination(
+			pageable,
+			contentQuery ->
+				contentQuery.selectFrom(member)
+							.leftJoin(member.team, team)
+							.where(usernameEq(condition.getUsername()),
+								   teamNameEq(condition.getTeamName()),
+								   ageGoe(condition.getAgeGoe()),
+								   ageLoe(condition.getAgeLoe())
+							),
+			countQuery ->
+				countQuery.select(member.id)
+						  .from(member)
+						  .leftJoin(member.team, team)
+						  .where(usernameEq(condition.getUsername()),
+								 teamNameEq(condition.getTeamName()),
+								 ageGoe(condition.getAgeGoe()),
+								 ageLoe(condition.getAgeLoe())
+						  )
+		);
+	}
+
+	private BooleanExpression usernameEq(String username) {
+		return hasText(username) ? member.username.eq(username) : null;
+	}
+
+	private BooleanExpression teamNameEq(String teamName) {
+		return hasText(teamName) ? team.name.eq(teamName) : null;
+	}
+
+	private BooleanExpression ageGoe(Integer ageGoe) {
+		return ageGoe != null ? member.age.goe(ageGoe) : null;
+	}
+
+	private BooleanExpression ageLoe(Integer ageLoe) {
+		return ageLoe != null ? member.age.loe(ageLoe) : null;
+	}
+
+}

--- a/querydsl/src/main/java/study/querydsl/repository/support/Querydsl4RepositorySupport.java
+++ b/querydsl/src/main/java/study/querydsl/repository/support/Querydsl4RepositorySupport.java
@@ -1,0 +1,106 @@
+package study.querydsl.repository.support;
+
+import java.util.List;
+import java.util.function.Function;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.JpaEntityInformation;
+import org.springframework.data.jpa.repository.support.JpaEntityInformationSupport;
+import org.springframework.data.jpa.repository.support.Querydsl;
+import org.springframework.data.querydsl.SimpleEntityPathResolver;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.Assert;
+
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+/**
+ * Querydsl 4.x 버전에 맞춘 Querydsl 지원 라이브러리
+ *
+ * @author Younghan Kim
+ * @see org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+ */
+@Repository
+public abstract class Querydsl4RepositorySupport {
+
+	private final Class domainClass;
+	private Querydsl querydsl;
+	private EntityManager entityManager;
+	private JPAQueryFactory queryFactory;
+
+	public Querydsl4RepositorySupport(Class<?> domainClass) {
+		Assert.notNull(domainClass, "Domain class must not be null!");
+		this.domainClass = domainClass;
+	}
+
+	@Autowired
+	public void setEntityManager(EntityManager entityManager) {
+		Assert.notNull(entityManager, "EntityManager must not be null!");
+		JpaEntityInformation entityInformation =
+			JpaEntityInformationSupport.getEntityInformation(domainClass, entityManager);
+		SimpleEntityPathResolver resolver = SimpleEntityPathResolver.INSTANCE;
+		EntityPath path = resolver.createPath(entityInformation.getJavaType());
+		this.entityManager = entityManager;
+		this.querydsl =
+			new Querydsl(entityManager, new PathBuilder<>(path.getType(), path.getMetadata()));
+		this.queryFactory = new JPAQueryFactory(entityManager);
+	}
+
+	@PostConstruct
+	public void validate() {
+		Assert.notNull(entityManager, "EntityManager must not be null!");
+		Assert.notNull(querydsl, "Querydsl must not be null!");
+		Assert.notNull(queryFactory, "QueryFactory must not be null!");
+	}
+
+	protected JPAQueryFactory getQueryFactory() {
+		return queryFactory;
+	}
+
+	protected Querydsl getQuerydsl() {
+		return querydsl;
+	}
+
+	protected EntityManager getEntityManager() {
+		return entityManager;
+	}
+
+	protected <T> JPAQuery<T> select(Expression<T> expr) {
+		return getQueryFactory().select(expr);
+	}
+
+	protected <T> JPAQuery<T> selectFrom(EntityPath<T> from) {
+		return getQueryFactory().selectFrom(from);
+	}
+
+	protected <T> Page<T> applyPagination(Pageable pageable,
+										  Function<JPAQueryFactory, JPAQuery> contentQuery) {
+
+		JPAQuery jpaQuery = contentQuery.apply(getQueryFactory());
+		List<T> content = getQuerydsl().applyPagination(pageable, jpaQuery)
+									   .fetch();
+		return PageableExecutionUtils.getPage(content, pageable, jpaQuery::fetchCount);
+	}
+
+	protected <T> Page<T> applyPagination(Pageable pageable,
+										  Function<JPAQueryFactory, JPAQuery> contentQuery,
+										  Function<JPAQueryFactory, JPAQuery> countQuery) {
+
+		JPAQuery jpaContentQuery = contentQuery.apply(getQueryFactory());
+		List<T> content = getQuerydsl().applyPagination(pageable, jpaContentQuery)
+									   .fetch();
+
+		JPAQuery countResult = countQuery.apply(getQueryFactory());
+		return PageableExecutionUtils.getPage(content, pageable, countResult::fetchCount);
+	}
+
+}

--- a/querydsl/src/test/java/study/querydsl/repository/MemberRepositoryTest.java
+++ b/querydsl/src/test/java/study/querydsl/repository/MemberRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import study.querydsl.dto.MemberSearchCondition;
 import study.querydsl.dto.MemberTeamDto;
 import study.querydsl.entity.Member;
+import study.querydsl.entity.QMember;
 import study.querydsl.entity.Team;
 
 @SpringBootTest
@@ -100,6 +101,29 @@ class MemberRepositoryTest {
 		assertThat(result.getSize()).isEqualTo(3);
 		assertThat(result.getContent()).extracting("username")
 									   .containsExactly("member1", "member2", "member3");
+	}
+
+	@Test
+	void querydslPredicateExecutor() {
+		QMember member = QMember.member;
+		Team teamA = new Team("teamA");
+		Team teamB = new Team("teamB");
+		em.persist(teamA);
+		em.persist(teamB);
+
+		Member member1 = new Member("member1", 10, teamA);
+		Member member2 = new Member("member2", 20, teamA);
+		Member member3 = new Member("member3", 30, teamB);
+		Member member4 = new Member("member4", 40, teamB);
+		em.persist(member1);
+		em.persist(member2);
+		em.persist(member3);
+		em.persist(member4);
+
+		Iterable<Member> result = memberRepository.findAll(
+			member.age.between(10, 40).and(member.username.eq("member1")));
+		result.forEach(m -> assertThat(m).extracting("username")
+										 .isEqualTo("member1"));
 	}
 
 }


### PR DESCRIPTION
- [x] 인터페이스 지원: QuerydslPredicateExecutor
- [x] Querydsl Web 지원
- [x] 리포지토리 지원: QuerydslRepositorySupport
- [x] Querydsl 지원 클래스 직접 구현

This closes #63 